### PR TITLE
Add an option to limit the distance for closest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fastest-levenshtein :rocket: 
+# fastest-levenshtein :rocket:
 > Fastest JS/TS implemenation of [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance).<br>
 > Measure the difference between two strings.
 
@@ -15,11 +15,11 @@ $ npm i fastest-levenshtein
 ```javascript
 const {distance, closest} = require('fastest-levenshtein')
 
-// Print levenshtein-distance between 'fast' and 'faster' 
+// Print levenshtein-distance between 'fast' and 'faster'
 console.log(distance('fast', 'faster'))
 //=> 2
 
-// Print string from array with lowest edit-distance to 'fast'
+// Print string from array with lowest edit-distance to 'fast' (3rd argument (number) can be a distance limit, default Infinity)
 console.log(closest('fast', ['slow', 'faster', 'fastest']))
 //=> 'faster'
 ```
@@ -28,7 +28,7 @@ console.log(closest('fast', ['slow', 'faster', 'fastest']))
 ```javascript
 import {distance, closest} from 'https://deno.land/x/fastest_levenshtein/mod.ts'
 
-// Print levenshtein-distance between 'fast' and 'faster' 
+// Print levenshtein-distance between 'fast' and 'faster'
 console.log(distance('fast', 'faster'))
 //=> 2
 
@@ -38,7 +38,7 @@ console.log(closest('fast', ['slow', 'faster', 'fastest']))
 ```
 
 ## Benchmark
-I generated 500 pairs of strings with length N. I measured the ops/sec each library achieves to process all the given pairs. Higher is better. 
+I generated 500 pairs of strings with length N. I measured the ops/sec each library achieves to process all the given pairs. Higher is better.
 
 | Test Target               | N=4   | N=8   | N=16  | N=32 | N=64  | N=128 | N=256 | N=512 | N=1024 |
 |---------------------------|-------|-------|-------|------|-------|-------|-------|-------|--------|

--- a/mod.ts
+++ b/mod.ts
@@ -124,12 +124,14 @@ const distance = (a: string, b: string): number => {
   return myers_x(a, b);
 };
 
-const closest = (str: string, arr: string[]): string => {
-  let min_distance = Infinity;
-  let min_index = 0;
+const closest = (str: string, arr: string[], limit: number = Infinity): string | undefined => {
+
+  let min_index: number | undefined;
+  let min_distance = limit;
+
   for (let i = 0; i < arr.length; i++) {
     const dist = distance(str, arr[i]);
-    if (dist < min_distance) {
+    if (dist <= min_distance) {
       min_distance = dist;
       min_index = i;
     }

--- a/mod.ts
+++ b/mod.ts
@@ -124,9 +124,9 @@ const distance = (a: string, b: string): number => {
   return myers_x(a, b);
 };
 
-const closest = (str: string, arr: string[], limit: number = Infinity): string | undefined => {
+const closest = (str: string, arr: string[], limit = Infinity): string | undefined => {
 
-  let min_index: number | undefined;
+  let min_index = -1 ;
   let min_distance = limit;
 
   for (let i = 0; i < arr.length; i++) {
@@ -136,7 +136,10 @@ const closest = (str: string, arr: string[], limit: number = Infinity): string |
       min_index = i;
     }
   }
-  return arr[min_index];
+
+  if (min_index > -1) {
+    return arr[min_index];
+  }
 };
 
 export { closest, distance };

--- a/test.ts
+++ b/test.ts
@@ -68,8 +68,7 @@ test("test find", () => {
 
 test("test find with a max distance no match", () => {
   const actual = closest("fast", ["This image shows the relative performance", "faster than the speed of light", "fastest to crash without an error"], 10);
-  const expected = undefined;
-  expect(actual).toBe(expected);
+  expect(actual).toBeUndefined();
 });
 
 test("test find with a max distance", () => {

--- a/test.ts
+++ b/test.ts
@@ -65,3 +65,15 @@ test("test find", () => {
   const expected = "faster";
   expect(actual).toBe(expected);
 });
+
+test("test find with a max distance no match", () => {
+  const actual = closest("fast", ["This image shows the relative performance", "faster than the speed of light", "fastest to crash without an error"], 10);
+  const expected = undefined;
+  expect(actual).toBe(expected);
+});
+
+test("test find with a max distance", () => {
+  const actual = closest("fast", ["slow", "faster than light", "fastest with a car", "super fast", "the fastest", "faster"], 10);
+  const expected = 'faster';
+  expect(actual).toBe(expected);
+});


### PR DESCRIPTION
If we do not find something within limit, we return undefined
instead of something even if it is super far from the base string.

One use case of `closest` can be, find within a max distance.

``` 
$ npm test

> npm run build && tsc test.ts && jest test.js
> tsc mod.ts --declaration

 PASS  ./test.js (30.204 s)
  ✓ test compare (29710 ms)
  ✓ test find (1 ms)
  ✓ test find with a max distance no match
  ✓ test find with a max distance

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        30.769 s
Ran all test suites matching /test.js/i.``` 