### PR TITLE
can use closest function with object array

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -126,11 +126,13 @@ const distance = (a: string, b: string): number => {
   return myers_x(a, b);
 };
 
-const closest = (str: string, arr: readonly string[]): string => {
+function closest(str: string, arr: readonly string[]): string;
+function closest<T>(str: string, arr: readonly T[], getter: (el: T) => string): T;
+function closest<T>(str: string, arr: readonly T[], getter: (el: T) => string = el => el as unknown as string): T {
   let min_distance = Infinity;
   let min_index = 0;
   for (let i = 0; i < arr.length; i++) {
-    const dist = distance(str, arr[i]);
+    const dist = distance(str, getter(arr[i]));
     if (dist < min_distance) {
       min_distance = dist;
       min_index = i;

--- a/test.ts
+++ b/test.ts
@@ -65,3 +65,14 @@ test("test find", () => {
   const expected = "faster";
   expect(actual).toBe(expected);
 });
+
+test("test find with objects", () => {
+  const data = [
+    { id: 1, content: "slow" },
+    { id: 2, content: "faster" },
+    { id: 3, content: "fastest" },
+  ];
+  const actual = closest("fast", data, ({ content }) => content);
+  const expected = data.find(({ content }) => content === "faster");
+  expect(actual).toStrictEqual(expected);
+});


### PR DESCRIPTION
It can be useful to use the "closest" function with an array of objects and not only with a string array.
To do this, you can pass a function as a third argument to access the desired element.